### PR TITLE
Basic commenting system

### DIFF
--- a/openach/static/boards/css/style.css
+++ b/openach/static/boards/css/style.css
@@ -111,3 +111,12 @@ body {
 .src-conflicting {
     background-color: #FCF3CF;
 }
+
+#id_honeypot {
+    display: none;
+}
+#id_comment {
+    height: 5em;
+    width: 40em;
+    resize: none;
+}

--- a/openach/templates/boards/detail.html
+++ b/openach/templates/boards/detail.html
@@ -3,6 +3,8 @@
 {% block title %}{{ board.board_title }} | Open Synthesis{% endblock %}
 
 {% load board_extras %}
+{% load comments %}
+{% load bootstrap %}
 
 {% block content %}
     <h1>Intelligence Board: <i>{{ board.board_title }}</i></h1>
@@ -97,5 +99,26 @@
         {% endfor %}
         </tbody>
     </table>
+
+    <h2>Comments</h2>
+
+    {% render_comment_list for board %}
+
+    {% if user.is_authenticated %}
+        {% get_comment_form for board as form %}
+        <form action="{% comment_form_target %}" method="POST">
+            {% csrf_token %}
+            {{ form.comment|bootstrap }}
+            {{ form.honeypot }}
+            {{ form.content_type }}
+            {{ form.object_pk }}
+            {{ form.timestamp }}
+            {{ form.security_hash }}
+            <input type="hidden" name="next" value="{{ board|board_url }}" />
+            <input class="btn btn-primary" type="submit" value="Add comment" id="id_submit" />
+        </form>
+    {% else %}
+        <p>Please <a href="/accounts/login/?next={{ board|board_url }}">log in</a> to leave a comment.</p>
+    {% endif %}
 
 {% endblock content %}

--- a/openach/templates/boards/evidence_detail.html
+++ b/openach/templates/boards/evidence_detail.html
@@ -3,6 +3,8 @@
 {% block title %}Evidence Detail | Open Synthesis{% endblock %}
 
 {% load board_extras %}
+{% load comments %}
+{% load bootstrap %}
 
 {% block content %}
 
@@ -66,5 +68,29 @@
         {% endfor %}
         </tbody>
     </table>
+
+    <h2>Comments</h2>
+
+    {% render_comment_list for evidence %}
+
+    {% if user.is_authenticated %}
+        {% get_comment_form for evidence as form %}
+        <form action="{% comment_form_target %}" method="POST">
+            {% csrf_token %}
+            {{ form.comment|bootstrap }}
+            {{ form.honeypot }}
+            {{ form.content_type }}
+            {{ form.object_pk }}
+            {{ form.timestamp }}
+            {{ form.security_hash }}
+            <input type="hidden" name="next" value="{% url 'openach:evidence_detail' evidence.id %}" />
+            <input class="btn btn-primary" type="submit" value="Add comment" id="id_submit" />
+        </form>
+    {% else %}
+        <p>
+            Please <a href="/accounts/login/?next={% url 'openach:evidence_detail' evidence.id %}">log in</a> to leave a
+            comment.
+        </p>
+    {% endif %}
 
 {% endblock %}

--- a/openintel/settings.py
+++ b/openintel/settings.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.sites',
     'django.contrib.sitemaps',
+    'django_comments',
     'bootstrapform',
     'openach',
     'allauth',

--- a/openintel/urls.py
+++ b/openintel/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     url(r'^accounts/profile', views.profile),
     url(r'^accounts/(?P<account_id>[0-9]+)/profile$', views.profile, name='profile'),
     url(r'^accounts/', include('allauth.urls')),
+    url(r'^comments/', include('django_comments.urls')),
     url(r'', include('openach.urls')),
     url(r'\.well-known/acme-challenge/(?P<challenge_key>[a-zA-Z0-9\-]+)$', views.certbot)
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ whitenoise==3.2.1
 django-pipeline>=1.6.8,<1.7.0
 coverage>=4.0,<5.0
 django-coverage-plugin>=1.3.1,<1.4.0
+django-contrib-comments>=1.7.2,<1.8.0


### PR DESCRIPTION
#4 implement a basic commenting system using django-contrib-comments. Currently supports single-thread commenting on boards and evidence. 
