### PR TITLE
Add validator for board name

### DIFF
--- a/openach/models.py
+++ b/openach/models.py
@@ -111,7 +111,7 @@ class Board(models.Model):
 
         ordering = ("-pub_date",)
 
-    validate_special = RegexValidator(r'^[0-9a-zA-Z ,.?()\-\/]*$', 'No special characters allowed.') # Allows commas, full-stops, question marks, parentheses, hyphens and forward slashes
+    validate_special = RegexValidator(r'^[0-9a-zA-Z ,.?()\-\/]*$', 'No special characters allowed.')
 
     board_title = models.CharField(
         max_length=BOARD_TITLE_MAX_LENGTH,

--- a/openach/models.py
+++ b/openach/models.py
@@ -15,6 +15,7 @@ from django.db.models import Q
 from django.urls import NoReverseMatch, reverse  # pylint: disable=no-name-in-module
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+from django.core.validators import RegexValidator
 from field_history.tracker import FieldHistoryTracker
 from slugify import slugify
 
@@ -110,6 +111,8 @@ class Board(models.Model):
 
         ordering = ("-pub_date",)
 
+    validate_special = RegexValidator(r'^[0-9a-zA-Z ,.?()\-\/]*$', 'No special characters allowed.') # Allows commas, full-stops, question marks, parentheses, hyphens and forward slashes
+
     board_title = models.CharField(
         max_length=BOARD_TITLE_MAX_LENGTH,
         db_index=True,
@@ -117,6 +120,7 @@ class Board(models.Model):
             "The board title. Typically phrased as a question asking about what happened in the past, "
             "what is happening currently, or what will happen in the future"
         ),
+        validators=[validate_special],
     )
 
     board_slug = models.SlugField(

--- a/openach/models.py
+++ b/openach/models.py
@@ -111,7 +111,8 @@ class Board(models.Model):
 
         ordering = ("-pub_date",)
 
-    validate_special = RegexValidator(r'^[0-9a-zA-Z ,.?()\-\/]*$', 'No special characters allowed.')
+    validate_special = RegexValidator(r'^((?![!@#^*~`|<>{}+=\[\]]).)*$', 'No special characters allowed.')
+    # When user clicks 'Create Board', validator stops any instance of these characters: !@#^*~`|<>{}+=[]
 
     board_title = models.CharField(
         max_length=BOARD_TITLE_MAX_LENGTH,


### PR DESCRIPTION
Addressing #62 ; customized RegexValidator to check for special characters, allowing for commas, full-stops, question marks, parentheses, hyphens and forward slashes.