### PR TITLE
Bump Node engine to 22 LTS to fix Heroku build

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -35,6 +35,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - uses: actions/setup-node@v6
         with:
+          node-version-file: package.json
           cache: npm
       - name: "Set up Python"
         uses: actions/setup-python@v6

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": ">=18.13 <19",
-    "npm": "8.x"
+    "node": ">=22 <23",
+    "npm": "10.x"
   }
 }


### PR DESCRIPTION
## Summary
- Node 18 lacks the global `crypto` object that `serialize-javascript` (pulled in via `css-minimizer-webpack-plugin`) requires, so the Heroku build fails in the CSS minify step with `ReferenceError: crypto is not defined`. Node 18 is also EOL on Heroku.
- Bump `engines.node` to `>=22 <23` (current LTS) and `engines.npm` to `10.x` (the version bundled with Node 22).
- Pin CI's `setup-node` to read from `package.json` so `engine-strict: true` doesn't surprise us on whatever default the runner ships.

## Test plan
- [x] `npm run build` succeeds locally on Node 22+ (verified on Node 24).
- [ ] Heroku build passes on push.
- [ ] GitHub Actions `integration` workflow passes on the new Node version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)