### PR TITLE
Remove third-party uv buildpack to fix Heroku build

### DIFF
--- a/app.json
+++ b/app.json
@@ -127,9 +127,6 @@
   },
   "buildpacks": [
     {
-      "url": "https://github.com/dropseed/heroku-buildpack-uv.git#5e4e0953a1db16940ac73fdc5edb6d4a58295413"
-    },
-    {
       "url": "heroku/nodejs"
     },
     {


### PR DESCRIPTION
## Summary
- Remove `dropseed/heroku-buildpack-uv` from `app.json`. It exports a `requirements.txt` at build time, which then collides with the committed `uv.lock` and causes `heroku/python` to abort with "Multiple Python package manager files were found".
- `heroku/python` on the heroku-26 stack now supports uv natively (detects `uv.lock` + `pyproject.toml`), so the third-party buildpack is no longer needed.

The same removal must also be done on the live Heroku app's buildpack list (not just `app.json`):
```
heroku buildpacks:remove https://github.com/dropseed/heroku-buildpack-uv.git#5e4e0953a1db16940ac73fdc5edb6d4a58295413
```

## Test plan
- [ ] `heroku buildpacks` shows only `heroku/nodejs` and `heroku/python`
- [ ] `git push heroku` succeeds; Python step installs from `uv.lock` natively
- [ ] App boots; release phase migrations run cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)